### PR TITLE
Clean up component list on `hubot status?`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Interaction with the StatusPage.io API to open and update incidents, change comp
 * Register the two values as environment variables when starting your bot (as usual with Hubot scripts).
  * `export HUBOT_STATUS_PAGE_ORGANIZATION=organization_for_status_page`
  * `export HUBOT_STATUS_PAGE_TOKEN=token_for_status_page`
+ * `export HUBOT_STATUS_PAGE_TWITTER_ENABLED=t_or_f`
 
 If you are using Heroku to host your bot, replace `export ...` with `heroku set:config ...`.
 

--- a/test/statuspage_test.coffee
+++ b/test/statuspage_test.coffee
@@ -4,7 +4,7 @@ chai.use require 'sinon-chai'
 
 expect = chai.expect
 
-describe 'hello-world', ->
+describe 'statuspage', ->
   beforeEach ->
     @robot =
       respond: sinon.spy()


### PR DESCRIPTION
- Groups broken components together instead of having to pick them out
- Disables Twitter integration by default, can be re-enabled via config
- Hides "working" components by default, can be re-enabled via config
