### PR TITLE
Switch API versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Interaction with the StatusPage.io API to open and update incidents, change comp
 ## Configuration
 
 * Register the two values as environment variables when starting your bot (as usual with Hubot scripts).
- * `export HUBOT_STATUS_PAGE_ORGANIZATION=organization_for_status_page`
+ * `export HUBOT_STATUS_PAGE_ID=page_id_for_account`
  * `export HUBOT_STATUS_PAGE_TOKEN=token_for_status_page`
  * `export HUBOT_STATUS_PAGE_TWITTER_ENABLED=t_or_f`
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-statuspage",
   "description": "Interaction with the StatusPage.io API to open and update incidents, change component status.",
-  "version": "0.0.4",
+  "version": "1.0.0",
   "author": "travis-ci",
   "license": "MIT",
   "keywords": [

--- a/src/statuspage.coffee
+++ b/src/statuspage.coffee
@@ -2,7 +2,7 @@
 #   Interaction with the StatusPage.io API to open and update incidents, change component status.
 #
 # Configuration:
-#   HUBOT_STATUS_PAGE_ORGANIZATION - Required
+#   HUBOT_STATUS_PAGE_ID - Required
 #   HUBOT_STATUS_PAGE_TOKEN - Required
 #   HUBOT_STATUS_PAGE_TWITTER_ENABLED - Optional: 't' or 'f'
 #   HUBOT_STATUS_PAGE_SHOW_WORKING - Optional: '1' or nothing
@@ -19,7 +19,7 @@
 #   roidrage, raventools
 
 module.exports = (robot) ->
-  baseUrl = "https://api.statuspage.io/v0/organizations/#{process.env.HUBOT_STATUS_PAGE_ORGANIZATION}"
+  baseUrl = "https://api.statuspage.io/v1/pages/#{process.env.HUBOT_STATUS_PAGE_ID}"
   authHeader = Authorization: "OAuth #{process.env.HUBOT_STATUS_PAGE_TOKEN}"
   componentStatuses =
     degraded: 'degraded performance',


### PR DESCRIPTION
StatusPage has published [API v1](https://doers.statuspage.io/api/v1/), which deprecates organization names in favour of page IDs.
